### PR TITLE
Closes #22

### DIFF
--- a/scripts/clean_branches.ps1
+++ b/scripts/clean_branches.ps1
@@ -1,0 +1,7 @@
+$branches = (git branch -l)
+foreach ($branch in $branches) {
+    $branch_name = $branch.Trim()
+    if (!($branch_name -eq "master" -or $branch_name.StartsWith("*"))) {
+        git branch -D $branch_name
+    }
+}

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,0 +1,16 @@
+$issue_titles = [ordered]@{}
+$issues = (gh issue list -a mtracewicz --json "number,title" | ConvertFrom-Json)
+if ($issues.Length -eq 0) {
+    exit
+}
+
+Write-Host "Nr.`tBranch"
+foreach ($issue in $issues) {
+    $issue_number = "$($issue.number)".PadLeft(5, '0')
+    $branch = ("$($issue_number)_$($issue.title)").Replace(" ", "_").Replace(":", "")
+    $issue_titles["$($issue.number)"] = $branch
+    Write-Host "$($issue.number)`t$branch"
+}
+
+$choice = Read-Host -Prompt "Please select an issue on which You want to work"
+git checkout -b $issue_titles[$choice]

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,8 +1,15 @@
 param(
-    [string]$assigne
+    [string]$assignee
 )
+
 $issue_titles = [ordered]@{}
-$issues = (gh issue list -a $assigne --json "number,title" | ConvertFrom-Json)
+$issues = ""
+if ($assignee -eq "") {
+    $issues = (gh issue list --json "number,title" | ConvertFrom-Json)
+}
+else {
+    $issues = (gh issue list -a $assignee --json "number,title" | ConvertFrom-Json)
+}
 if ($issues.Length -eq 0) {
     exit
 }

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,5 +1,8 @@
+param(
+    [string]$assigne
+)
 $issue_titles = [ordered]@{}
-$issues = (gh issue list -a mtracewicz --json "number,title" | ConvertFrom-Json)
+$issues = (gh issue list -a $assigne --json "number,title" | ConvertFrom-Json)
 if ($issues.Length -eq 0) {
     exit
 }


### PR DESCRIPTION
Added two scripts to automate common tasks with git.
The first script creates a branch that follows our naming convention.
It scans all issues in the repository or the ones assigned to a person passed as a parameter and creates a proper branch name for each of them and then asks the user which one should be created. This one requires GitHub CLI to be installed and logged in.
Example usages `create_branch.ps1`  and  `create_branch.ps1 -assignee mtracewicz`

The second one deletes all local branches except for the `master` and the current one.