### PR TITLE
Closes #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 [![Build and test - backend](https://github.com/ksummarized/ksummarized.com/actions/workflows/build-and-test-backend.yml/badge.svg)](https://github.com/ksummarized/ksummarized.com/actions/workflows/build-and-test-backend.yml)
 [![Lint and test - frontend](https://github.com/ksummarized/ksummarized.com/actions/workflows/lint-and-test-frontend.yml/badge.svg)](https://github.com/ksummarized/ksummarized.com/actions/workflows/lint-and-test-frontend.yml)
+
+## Scripts
+
+    Directory `scripts` contains some helpful scripts which automate some parts of working with this directory.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 
 ## Scripts
 
-    Directory `scripts` contains some helpful scripts which automate some parts of working with this directory.
+Directory `scripts` contains some helpful scripts which automate some parts of working with this directory.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,24 @@ Two out of those (`create_branch.ps1` and `create_pr.ps1`) require user to have 
 
 ## Usage:
 
-- `create_branch.ps1` it creates branch which follows naming convention based on issue number and title.
-  By default it asks based on issues assigned to the user. This can be changed with `-Assignee` flag.
-- `clean_branches.ps1` clears all of the local branches except for master and the current one.
-- `create_pr.ps1` creates a PR in this repo
+- `create_pr.ps1` - creates a PR in this repo.
+
+  - Params:
+
+    - Reviewer [string] (required) - the person assigned as a reviewer for this PR.
+    - BodyFile [file path] (required) - a path to the file with content for PR description written in markdown.
+
+  - Examples:
+
+    - `.\scripts\create_pr.ps1 -Reviewer sojusan -BodyFile .\text.md`
+
+- `create_branch.ps1` - it creates branch which follows naming convention based on issue number and title.
+
+  - Params:
+
+    - Assignee [string] (defaults to current user) - person who's issues will be presented as options
+
+  - Examples:
+    - `.\scripts\create_branch.ps1 -Assignee sojusan`
+
+- `clean_branches.ps1` - clears all of the local branches except for master and the current one.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+# Scripts
+
+This directory contains scripts which automate common tasks in this repository.
+Right now there are this scripts:
+
+- `create_branch.ps1`
+- `clean_branches.ps1`
+- `create_pr.ps1`
+
+Two out of those (`create_branch.ps1` and `create_pr.ps1`) require user to have GitHub CLI installed and to be logged in.
+
+## Usage:
+
+- `create_branch.ps1` it creates branch which follows naming convention based on issue number and title.
+  By default it asks based on issues assigned to the user. This can be changed with `-Assignee` flag.
+- `clean_branches.ps1` clears all of the local branches except for master and the current one
+- `create_pr.ps1` creates a PR in this repo

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@ Two out of those (`create_branch.ps1` and `create_pr.ps1`) require user to have 
 
 - `create_branch.ps1` it creates branch which follows naming convention based on issue number and title.
   By default it asks based on issues assigned to the user. This can be changed with `-Assignee` flag.
-- `clean_branches.ps1` clears all of the local branches except for master and the current one
+- `clean_branches.ps1` clears all of the local branches except for master and the current one.
 - `create_pr.ps1` creates a PR in this repo

--- a/scripts/clean_branches.ps1
+++ b/scripts/clean_branches.ps1
@@ -1,0 +1,7 @@
+$branches = (git branch -l)
+foreach ($branch in $branches) {
+    $branch_name = $branch.Trim()
+    if (!($branch_name -eq "master" -or $branch_name.StartsWith("*"))) {
+        git branch -D $branch_name
+    }
+}

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,0 +1,16 @@
+$issue_titles = [ordered]@{}
+$issues = (gh issue list -a mtracewicz --json "number,title" | ConvertFrom-Json)
+if ($issues.Length -eq 0) {
+    exit
+}
+
+Write-Host "Nr.`tBranch"
+foreach ($issue in $issues) {
+    $issue_number = "$($issue.number)".PadLeft(5, '0')
+    $branch = ("$($issue_number)_$($issue.title)").Replace(" ", "_").Replace(":", "")
+    $issue_titles["$($issue.number)"] = $branch
+    Write-Host "$($issue.number)`t$branch"
+}
+
+$choice = Read-Host -Prompt "Please select an issue on which You want to work"
+git checkout -b $issue_titles[$choice]

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,8 +1,15 @@
 param(
-    [string]$assigne
+    [string]$assignee
 )
+
 $issue_titles = [ordered]@{}
-$issues = (gh issue list -a $assigne --json "number,title" | ConvertFrom-Json)
+$issues = ""
+if ($assignee -eq "") {
+    $issues = (gh issue list --json "number,title" | ConvertFrom-Json)
+}
+else {
+    $issues = (gh issue list -a $assignee --json "number,title" | ConvertFrom-Json)
+}
 if ($issues.Length -eq 0) {
     exit
 }

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,15 +1,9 @@
 param(
-    [string]$assignee
+    [string]$Assignee = "@me"
 )
 
 $issue_titles = [ordered]@{}
-$issues = ""
-if ($assignee -eq "") {
-    $issues = (gh issue list --json "number,title" | ConvertFrom-Json)
-}
-else {
-    $issues = (gh issue list -a $assignee --json "number,title" | ConvertFrom-Json)
-}
+$issues = (gh issue list -a $Assignee --json "number,title" | ConvertFrom-Json)
 if ($issues.Length -eq 0) {
     exit
 }

--- a/scripts/create_branch.ps1
+++ b/scripts/create_branch.ps1
@@ -1,5 +1,8 @@
+param(
+    [string]$assigne
+)
 $issue_titles = [ordered]@{}
-$issues = (gh issue list -a mtracewicz --json "number,title" | ConvertFrom-Json)
+$issues = (gh issue list -a $assigne --json "number,title" | ConvertFrom-Json)
 if ($issues.Length -eq 0) {
     exit
 }

--- a/scripts/create_pr.ps1
+++ b/scripts/create_pr.ps1
@@ -1,12 +1,12 @@
 param(
     [Parameter(Mandatory = $true)]
-    [string]$reviewer,
+    [string]$Reviewer,
     [Parameter(Mandatory = $true)]
-    [string]$bodyFile
+    [string]$BodyFile
 )
 
 $branchs = (git branch -l)
 $current_branch = $branchs.Where({ $_.StartsWith('*') })
 $issue_number = $current_branch.Substring(2, 5).TrimStart('0')
 
-gh pr create -a `@me -r $reviewer -t "Closes #$($issue_number)" -B master -F $bodyFile
+gh pr create -a `@me -r $Reviewer -t "Closes #$($issue_number)" -B master -F $BodyFile

--- a/scripts/create_pr.ps1
+++ b/scripts/create_pr.ps1
@@ -1,0 +1,12 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$reviewer,
+    [Parameter(Mandatory = $true)]
+    [string]$bodyFile
+)
+
+$branchs = (git branch -l)
+$current_branch = $branchs.Where({ $_.StartsWith('*') })
+$issue_number = $current_branch.Substring(2, 5).TrimStart('0')
+
+gh pr create -a `@me -r $reviewer -t "Closes #$($issue_number)" -B master -F $bodyFile

--- a/scripts/create_pr.ps1
+++ b/scripts/create_pr.ps1
@@ -5,8 +5,8 @@ param(
     [string]$BodyFile
 )
 
-$branchs = (git branch -l)
-$current_branch = $branchs.Where({ $_.StartsWith('*') })
+$branches = (git branch -l)
+$current_branch = $branches.Where({ $_.StartsWith('*') })
 $issue_number = $current_branch.Substring(2, 5).TrimStart('0')
 
 gh pr create -a `@me -r $Reviewer -t "Closes #$($issue_number)" -B master -F $BodyFile


### PR DESCRIPTION
Added three scripts to automate common tasks with git.
Two of them require GitHub CLI to be installed and logged in.

The first script creates a branch that follows our naming convention.
It scans all issues in the repository assigned to a person (by default it is a user logged into GitHub CLI, can be changed with `-Assignee` parameter).
Then creates a proper branch name for each of them and then asks the user which one should be created. 
Example usages `create_branch.ps1` and `create_branch.ps1 -Assignee mtracewicz`

The second one deletes all local branches except for the master and the current one.

The third one creates a PR. It has two required parameters: reviewer and a markdown file containing PR text.
Example usage `.\scripts\create_pr.ps1 -Reviewer sojusan -BodyFile .\text.md`  <- this is how this PR has been created 😉  