### PR TITLE
Closes #14

### DIFF
--- a/.github/workflows/build-and-test-backend.yml
+++ b/.github/workflows/build-and-test-backend.yml
@@ -12,7 +12,7 @@ on:
       - "**.csproj"
 
 env:
-  DOTNET_VERSION: "5.0.301" # The .NET SDK version to use
+  DOTNET_VERSION: "6.0.100" # The .NET SDK version to use
 
 jobs:
   build-and-test-backend:

--- a/.github/workflows/publish-to-container-registry.yml
+++ b/.github/workflows/publish-to-container-registry.yml
@@ -7,7 +7,7 @@ on:
       - "backend/**"
 
 env:
-  DOTNET_VERSION: "5.0.301" # The .NET SDK version to use
+  DOTNET_VERSION: "6.0.100" # The .NET SDK version to use
 
 jobs:
   build-and-publish-backend:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-alpine3.14-amd64 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["src/api/api.csproj", "src/api/"]
 RUN dotnet restore "src/api/api.csproj"

--- a/backend/src/api/api.csproj
+++ b/backend/src/api/api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f7cb2e8e-61a4-4a0a-9259-839230fcfe2d</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>

--- a/backend/test/ksummarized.UnitTests/ksummarized.UnitTests.csproj
+++ b/backend/test/ksummarized.UnitTests/ksummarized.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.301"
+    "version": "6.0",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
I have upgraded our backend project to use .NET 6 as it came out today.
Changes included:
* target framework for API and test projects
* base Docker images used to create our image
* SDK version in GitHub actions
* global.json which specifies which .NET version should be used by the CLI