### PR TITLE
Closes #41 PR reminder

### DIFF
--- a/.github/workflows/inactive-pull-request-reminder.yml
+++ b/.github/workflows/inactive-pull-request-reminder.yml
@@ -1,0 +1,15 @@
+name: "Inactive PR reminder"
+on:
+  schedule:
+    # Run everyday at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  inactive-pr-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sojusan/github-action-reminder@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reminder_message: "Two days have passed since the last activity. Please take care of this PR."
+          inactivity_deadline_hours: 48


### PR DESCRIPTION
Add a new GitHub workflow "inactive-pull-request-reminder".

As we discussed, I found a solution to remind us to take action on pending PRs. I created a custom GitHub action on my profile and made it publicly available under the MIT license.

This action will post a comment with reviewers marked every two days of inactivity on PR.

Example of the message content:

@sojusan
Two days have passed since the last activity. Please take care of this PR.