### PR TITLE
Closes #43 Add SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud-backend-build-and-analyze.yml
+++ b/.github/workflows/sonarcloud-backend-build-and-analyze.yml
@@ -1,10 +1,16 @@
-name: SonarCloud
+name: SonarCloud Backend
 on:
   push:
     branches:
       - master
+    paths:
+      - "**.cs"
+      - "**.csproj"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "**.cs"
+      - "**.csproj"
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/sonarcloud-backend-build-and-analyze.yml
+++ b/.github/workflows/sonarcloud-backend-build-and-analyze.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'zulu' # Alternative distribution options are available.
+          distribution: "zulu" # Alternative distribution options are available.
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -45,11 +45,11 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ksummarized_ksummarized.com" /o:"ksummarized" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ksummarized_ksummarized.com_backend" /o:"ksummarized" /d:sonar.login="${{ secrets.SONAR_TOKEN_BACKEND }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet restore backend/ksummarized.sln
           dotnet build backend/ksummarized.sln
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN_BACKEND }}"

--- a/.github/workflows/sonarcloud-build-and-analyze.yml
+++ b/.github/workflows/sonarcloud-build-and-analyze.yml
@@ -44,5 +44,6 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"ksummarized_ksummarized.com" /o:"ksummarized" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build backend/ksummarized.sln --no-restore
+          dotnet restore backend/ksummarized.sln
+          dotnet build backend/ksummarized.sln
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud-build-and-analyze.yml
+++ b/.github/workflows/sonarcloud-build-and-analyze.yml
@@ -44,5 +44,5 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"ksummarized_ksummarized.com" /o:"ksummarized" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build --configuration Release --no-restore
+          dotnet build backend/ksummarized.sln --no-restore
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud-build-and-analyze.yml
+++ b/.github/workflows/sonarcloud-build-and-analyze.yml
@@ -1,0 +1,48 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: windows-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu' # Alternative distribution options are available.
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v3
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: powershell
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ksummarized_ksummarized.com" /o:"ksummarized" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          dotnet build --configuration Release --no-restore
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud-frontend-analyze.yml
+++ b/.github/workflows/sonarcloud-frontend-analyze.yml
@@ -1,0 +1,26 @@
+name: SonarCloud Frontend
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.ts"
+      - "**.tsx"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**.ts"
+      - "**.tsx"
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud-frontend-analyze.yml
+++ b/.github/workflows/sonarcloud-frontend-analyze.yml
@@ -2,7 +2,7 @@ name: SonarCloud Frontend
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - "**.ts"
       - "**.tsx"

--- a/.github/workflows/sonarcloud-frontend-analyze.yml
+++ b/.github/workflows/sonarcloud-frontend-analyze.yml
@@ -23,4 +23,10 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+        with:
+          projectBaseDir: frontend
+          args: >
+            -Dsonar.organization=ksummarized
+            -Dsonar.projectKey=ksummarized_ksummarized.com_frontend
+            -Dsonar.vebose=true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ksummarized.com
 
+[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/summary/new_code?id=ksummarized_ksummarized.com_frontend)
 [![Build and test - backend](https://github.com/ksummarized/ksummarized.com/actions/workflows/build-and-test-backend.yml/badge.svg)](https://github.com/ksummarized/ksummarized.com/actions/workflows/build-and-test-backend.yml)
 [![Lint and test - frontend](https://github.com/ksummarized/ksummarized.com/actions/workflows/lint-and-test-frontend.yml/badge.svg)](https://github.com/ksummarized/ksummarized.com/actions/workflows/lint-and-test-frontend.yml)
 


### PR DESCRIPTION
I added configuration for SonarCloud

Changes in organization settings and our repository:
* In the settings of our organization in the `GitHub Apps` section, `SonarCloud` has been added, this application has been added with the `Free` plan, which can be checked by the entry in the organization settings in the `Billing and plans` section.
* 2 `Repository secrets` have been added:
   * SONAR_TOKEN_BACKEND - for interacting with the backend application on sonarcloud.io
   * SONAR_TOKEN_FRONTEND - for interacting with the frontend application on sonarcloud.io

Changes in files:
* I added a badge to the `README` file to clearly indicate the use of the SonarCloud application in the project.
* Added GitHub Actions configuration to run SonarCloud analysis for backend and frontend projects.

How to work with SonarCloud:
GitHub Actions that are added perform analysis of the added code and then the results are sent to our project page at [sonarcloud.io](https://sonarcloud.io/). The result of this analysis is also included in the commentary on the PR.
On the SonarCloud page, you should see two projects:
* ksummarized_ksummarized.com_backend
* ksummarized_ksummarized.com_frontend

There are two projects and not one because our repository is a `monorepo`, so according to the [SonarCloud documentation](https://docs.sonarcloud.io/advanced-setup/monorepo-support/) we had to split it into two projects.

Please check if you have access to both projects after logging into SonarCloud.