### PR TITLE
Closes #50 Update github-action-reminder configuration

### DIFF
--- a/.github/workflows/inactive-pull-request-reminder.yml
+++ b/.github/workflows/inactive-pull-request-reminder.yml
@@ -13,3 +13,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reminder_message: "Two days have passed since the last activity. Please take care of this PR."
           inactivity_deadline_hours: 48
+          default_users_to_notify: |
+            @Sojusan
+            @mtracewicz


### PR DESCRIPTION
Now when someone creates a PR and no reviewer is assigned to it, a reminder comment will be made after 2 days of inactivity, but since no one is tagged, a reminder email from GitHub is not sent.

The GitHub Action that is responsible for this has been updated. In version 1.1.0 you can mark default people who will be marked without assigning a reviewer.

In this PR I have added both of us as default people for taking care of new PRs.