### PR TITLE
Limit reminder action to main repo

### DIFF
--- a/.github/workflows/inactive-pull-request-reminder.yml
+++ b/.github/workflows/inactive-pull-request-reminder.yml
@@ -6,11 +6,13 @@ on:
 
 jobs:
   inactive-pr-reminder:
+    permissions:
+      pull-requests: write
+    if: github.repository == 'ksummarized/ksummarized.com'
     runs-on: ubuntu-latest
     steps:
       - uses: sojusan/github-action-reminder@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           reminder_message: "Two days have passed since the last activity. Please take care of this PR."
           inactivity_deadline_hours: 48
           default_users_to_notify: |


### PR DESCRIPTION
Limits reminder action to run only in the main repo. Without the `if` statement our action will run in the forks, which could result in additional notifications.
The GitHub action was updated and there is no longer a need to pass the GitHub token explicitly.